### PR TITLE
Adding galactic support for tf2_eigen

### DIFF
--- a/racecar_utils/CMakeLists.txt
+++ b/racecar_utils/CMakeLists.txt
@@ -5,6 +5,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Set ROS_DISTRO macros
+set(ROS_DISTRO $ENV{ROS_DISTRO})
+if(${ROS_DISTRO} STREQUAL "rolling")
+  add_compile_definitions(ROS_DISTRO_ROLLING)
+elseif(${ROS_DISTRO} STREQUAL "galactic")
+  add_compile_definitions(ROS_DISTRO_GALACTIC)
+elseif(${ROS_DISTRO} STREQUAL "humble")
+  add_compile_definitions(ROS_DISTRO_HUMBLE)
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosbag2_cpp REQUIRED)

--- a/racecar_utils/src/odom_to_tf.cpp
+++ b/racecar_utils/src/odom_to_tf.cpp
@@ -3,7 +3,11 @@
 #include <functional>
 #include <exception>
 #include <iostream>
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_eigen/tf2_eigen.h>
+#else
 #include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 OdomToTFNode::OdomToTFNode() : rclcpp::Node("odom_to_tf_node")
 {


### PR DESCRIPTION
Since the README specifies Galactic as well. This change is required for `odom_to_tf` to compile in Galactic. Based off Autoware.Universe [examples](https://github.com/autowarefoundation/autoware.universe/blob/18fdbef144311981121ea303532dfed536f77a0a/planning/obstacle_velocity_limiter/src/pointcloud_utils.cpp#L25)